### PR TITLE
🧹 Refactor manual Response to text() helper in API routes

### DIFF
--- a/src/routes/api/post/[id]/+server.ts
+++ b/src/routes/api/post/[id]/+server.ts
@@ -1,3 +1,4 @@
+import { text } from '@sveltejs/kit';
 export const DELETE = async ({ locals: { supabase, safeGetSession }, params }) => {
 	const { session } = await safeGetSession();
 
@@ -20,7 +21,7 @@ export const DELETE = async ({ locals: { supabase, safeGetSession }, params }) =
 		throw new Error('Internal Server Error');
 	}
 
-	return new Response('Post deleted', { status: 200 });
+	return text('Post deleted');
 };
 
 export const PATCH = async ({ locals: { supabase, safeGetSession }, params, request }) => {
@@ -78,5 +79,5 @@ export const PATCH = async ({ locals: { supabase, safeGetSession }, params, requ
 		}
 	}
 
-	return new Response('Post updated', { status: 200 });
+	return text('Post updated');
 };


### PR DESCRIPTION
🎯 **What:** Replaced redundant manual Response object initializations for text responses with SvelteKit's `text()` helper in `src/routes/api/post/[id]/+server.ts`.\n💡 **Why:** Reduces verbosity and improves the overall maintainability and readability of the codebase by leveraging built-in framework utilities.\n✅ **Verification:** Verified by checking types with `npm run check` and running linting rules. Code review was completed and non-related auto-formatting/package-lock changes were properly reverted to keep the PR clean.\n✨ **Result:** A cleaner and more idiomatic implementation of API routes in SvelteKit.

---
*PR created automatically by Jules for task [5682230057730012360](https://jules.google.com/task/5682230057730012360) started by @Sparkier*