### PR TITLE
🔒 Fix HTML Injection in Daily Digest Emails

### DIFF
--- a/src/routes/api/newsletter/daily-digest/+server.ts
+++ b/src/routes/api/newsletter/daily-digest/+server.ts
@@ -11,6 +11,15 @@ import type { RequestHandler } from './$types';
 
 const resend = new Resend(RESEND_API_KEY);
 
+function escapeHtml(unsafe: string): string {
+	return unsafe
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#039;');
+}
+
 export const POST: RequestHandler = async ({ locals: { supabase }, request }) => {
 	const authHeader = request.headers.get('Authorization');
 	if (authHeader !== `Bearer ${DAILY_DIGEST_SECRET_KEY}`) {
@@ -51,9 +60,12 @@ export const POST: RequestHandler = async ({ locals: { supabase }, request }) =>
 
 		posts.forEach((post) => {
 			const postLink = `${siteUrl}`;
+			const safeTitle = escapeHtml(post.title);
+			const safeDesc = post.description ? escapeHtml(post.description.substring(0, 100)) : '';
+
 			postsText += `- ${post.title}\n   ${post.description?.substring(0, 100)}...\n   View: ${postLink}\n\n`;
 			linkedinText += `- ${post.title}\n`;
-			postsHtml += `<li><a href="${postLink}"><strong>${post.title}</strong></a><br/>${post.description?.substring(0, 100)}...</li>`;
+			postsHtml += `<li><a href="${postLink}"><strong>${safeTitle}</strong></a><br/>${safeDesc}...</li>`;
 		});
 		postsHtml += `</ul>`;
 

--- a/supabase/functions/daily-digest-trigger/deno.json
+++ b/supabase/functions/daily-digest-trigger/deno.json
@@ -1,3 +1,3 @@
 {
-  "imports": {}
+	"imports": {}
 }


### PR DESCRIPTION
🎯 **What:** Fixed an HTML injection vulnerability in the daily digest email endpoint (`src/routes/api/newsletter/daily-digest/+server.ts`).
⚠️ **Risk:** Post titles and descriptions were being directly interpolated into the HTML body of outgoing digest emails without escaping. An attacker could potentially submit a malicious post containing harmful HTML or scripts (e.g., tracking pixels, phishing links) which would then be executed/rendered in the email clients of all subscribers when the daily digest is sent.
🛡️ **Solution:** Added an `escapeHtml` utility function to safely escape potentially dangerous characters (`&`, `<`, `>`, `"`, `'`) and applied it to `post.title` and `post.description` before constructing the `postsHtml` payload.

---
*PR created automatically by Jules for task [5430843836571586338](https://jules.google.com/task/5430843836571586338) started by @Sparkier*