### PR TITLE
🧹 Extract hardcoded email addresses to environment variables

### DIFF
--- a/src/routes/api/newsletter/daily-digest/+server.ts
+++ b/src/routes/api/newsletter/daily-digest/+server.ts
@@ -1,5 +1,6 @@
 import {
 	DAILY_DIGEST_SECRET_KEY,
+	FROM_EMAIL,
 	LINKEDIN_ACCESS_TOKEN,
 	LINKEDIN_ORGANIZATION_ID,
 	RESEND_API_KEY,
@@ -73,7 +74,7 @@ export const POST: RequestHandler = async ({ locals: { supabase }, request }) =>
 
 		const broadcast = await resend.broadcasts.create({
 			name: `Daily Digest ${new Date().toLocaleDateString()}`,
-			from: 'info@vispositions.com',
+			from: FROM_EMAIL,
 			subject: subject,
 			text: textBody,
 			html: htmlBody,

--- a/src/routes/api/webhooks/post/+server.ts
+++ b/src/routes/api/webhooks/post/+server.ts
@@ -1,4 +1,4 @@
-import { ADMIN_EMAIL, RESEND_API_KEY } from '$env/static/private';
+import { ADMIN_EMAIL, FROM_EMAIL, RESEND_API_KEY } from '$env/static/private';
 import { json } from '@sveltejs/kit';
 import { Resend } from 'resend';
 
@@ -9,7 +9,7 @@ export async function POST({ request }) {
 		const payload = await request.json();
 
 		await resend.emails.send({
-			from: 'info@vispositions.com',
+			from: FROM_EMAIL,
 			to: ADMIN_EMAIL,
 			subject: 'New Post Submitted',
 			text: `A new post was submitted: \n\nTitle: ${payload.title}\n\nContent: ${payload.description}`


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was hardcoded sender email addresses in `src/routes/api/webhooks/post/+server.ts` and `src/routes/api/newsletter/daily-digest/+server.ts`.
💡 **Why:** Moving these values to a `FROM_EMAIL` environment variable makes the code cleaner, configurable across different environments (e.g., staging vs. prod), and avoids scattered hardcoded values if the email ever changes.
✅ **Verification:** Ran `npm run format`, `npm run lint`, and `npm run check`. Confirmed that no new errors were introduced and that the endpoints compile correctly after creating a `.env` file with the `FROM_EMAIL` placeholder.
✨ **Result:** A more robust and cleaner way to configure emails through environment variables instead of hardcoded strings.

---
*PR created automatically by Jules for task [11465811394427291919](https://jules.google.com/task/11465811394427291919) started by @Sparkier*