### PR TITLE
🔒 Fix mass assignment privilege escalation in post update

### DIFF
--- a/src/routes/api/post/[id]/+server.ts
+++ b/src/routes/api/post/[id]/+server.ts
@@ -41,7 +41,6 @@ export const PATCH = async ({ locals: { supabase, safeGetSession }, params, requ
 		contact: data.contact,
 		industry: data.industry,
 		education: data.education,
-		vetted: data.vetted,
 		expiration_date: data.expiration_date
 	};
 


### PR DESCRIPTION
🎯 **What:** Fixed a Mass Assignment Privilege Escalation vulnerability in the post update endpoint.
⚠️ **Risk:** The vulnerability allowed malicious users to arbitrarily modify the `vetted` status of a post by sending `vetted: true` in their request payload, potentially bypassing the administrative approval process.
🛡️ **Solution:** Removed the `vetted: data.vetted` mapping from the `updateData` object within `src/routes/api/post/[id]/+server.ts`. This ensures that only safe, user-editable fields (title, description, contact, industry, education, expiration_date) can be updated via this endpoint.

---
*PR created automatically by Jules for task [15216540996780782577](https://jules.google.com/task/15216540996780782577) started by @Sparkier*