### PR TITLE
🧹 Refactor: improve type safety in PostFilters onselect function by removing any[]

### DIFF
--- a/src/lib/components/PostFilters.svelte
+++ b/src/lib/components/PostFilters.svelte
@@ -99,9 +99,9 @@
 		};
 	}
 
-	function onselect(args: any[], type: string) {
+	function onselect(args: [string, unknown], type: string) {
 		if (args[1] && typeof args[1] === 'object' && 'title' in args[1]) {
-			const elements = args[1].title;
+			const elements = (args[1] as { title: string[] }).title;
 			if (type === 'keyword') {
 				keywords = elements;
 			} else if (type === 'education') {
@@ -127,8 +127,8 @@
 		data={industryData}
 		options={vegaOptions}
 		signalListeners={{
-			selected: (...args) => {
-				onselect(args, 'industry');
+			selected: (name: string, value: unknown) => {
+				onselect([name, value], 'industry');
 			}
 		}}
 	/>
@@ -137,8 +137,8 @@
 		data={educationData}
 		options={vegaOptions}
 		signalListeners={{
-			selected: (...args) => {
-				onselect(args, 'education');
+			selected: (name: string, value: unknown) => {
+				onselect([name, value], 'education');
 			}
 		}}
 	/>
@@ -147,8 +147,8 @@
 		data={keywordData}
 		options={vegaOptions}
 		signalListeners={{
-			selected: (...args) => {
-				onselect(args, 'keyword');
+			selected: (name: string, value: unknown) => {
+				onselect([name, value], 'keyword');
 			}
 		}}
 	/>


### PR DESCRIPTION
🎯 **What:** Replaced the explicit `any[]` type parameter in the `onselect` function of `src/lib/components/PostFilters.svelte` with a specific tuple type `[string, unknown]`, and updated the event handlers to pass correct parameter types.

💡 **Why:** This resolves a code health issue where an explicit `any[]` array was used. It enhances type safety, making it clear that Vega signal listeners provide `[name, value]` arguments, and allows us to get proper typing locally.

✅ **Verification:** Verified by running `npm run check` which returned no type errors in `PostFilters.svelte`. Formatted and linted the code successfully. The Vitest test suite also passed.

✨ **Result:** Improved type safety and clearer data structures for event callbacks in the `PostFilters` component without altering runtime logic.

---
*PR created automatically by Jules for task [17018784366901902428](https://jules.google.com/task/17018784366901902428) started by @Sparkier*