### PR TITLE
🧪 test: add error tests for unauthorized google sheets webhook execution

### DIFF
--- a/src/routes/api/webhooks/google-sheets/server.test.ts
+++ b/src/routes/api/webhooks/google-sheets/server.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { POST } from './+server';
+
+vi.mock('$env/static/private', () => ({
+	WEBHOOK_SECRET: 'test_webhook_secret',
+	SUPABASE_SERVICE_ROLE_KEY: 'test_supabase_service_role_key'
+}));
+
+vi.mock('$env/static/public', () => ({
+	PUBLIC_SUPABASE_URL: 'https://test.supabase.co'
+}));
+
+vi.mock('@supabase/supabase-js', () => {
+    return {
+        createClient: vi.fn().mockImplementation(() => {
+            return {};
+        })
+    };
+});
+
+describe('Google Sheets Webhook API', () => {
+	it('should return 401 if Authorization header is missing', async () => {
+		const request = new Request('http://localhost/api/webhooks/google-sheets', {
+			method: 'POST',
+			body: JSON.stringify([{ title: 'test' }])
+		});
+
+		const response = await POST({ request } as any);
+
+		expect(response.status).toBe(401);
+		expect(await response.text()).toBe('Unauthorized');
+	});
+
+	it('should return 401 if Authorization header is invalid', async () => {
+		const request = new Request('http://localhost/api/webhooks/google-sheets', {
+			method: 'POST',
+			headers: {
+				'Authorization': 'Bearer wrong_secret'
+			},
+			body: JSON.stringify([{ title: 'test' }])
+		});
+
+		const response = await POST({ request } as any);
+
+		expect(response.status).toBe(401);
+		expect(await response.text()).toBe('Unauthorized');
+	});
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for the unauthorized execution of the Google Sheets webhook endpoint (`src/routes/api/webhooks/google-sheets/+server.ts`).
📊 **Coverage:** The new tests now cover scenarios where the `Authorization` header is either missing entirely or contains an invalid bearer token. 
✨ **Result:** The improvement in test coverage ensures that any future changes won't accidentally expose the webhook endpoint to unauthenticated access, maintaining secure integrations.

---
*PR created automatically by Jules for task [5742622351214365683](https://jules.google.com/task/5742622351214365683) started by @Sparkier*