### PR TITLE
🧪 Add tests for missing required fields in google sheets webhook

### DIFF
--- a/src/routes/api/webhooks/google-sheets/server.test.ts
+++ b/src/routes/api/webhooks/google-sheets/server.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { POST } from './+server';
+
+// Mock env vars
+vi.mock('$env/static/private', () => ({
+	WEBHOOK_SECRET: 'test_webhook_secret',
+	SUPABASE_SERVICE_ROLE_KEY: 'test_service_key'
+}));
+
+vi.mock('$env/static/public', () => ({
+	PUBLIC_SUPABASE_URL: 'http://localhost'
+}));
+
+// Mock supabase client
+vi.mock('@supabase/supabase-js', () => {
+	return {
+		createClient: vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnThis(),
+			select: vi.fn().mockReturnThis(),
+			eq: vi.fn().mockReturnThis(),
+			in: vi.fn().mockReturnThis(),
+			insert: vi.fn().mockReturnThis(),
+			single: vi.fn().mockResolvedValue({ data: { id: 1 }, error: null }),
+			maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+		})
+	};
+});
+
+describe('Google Sheets Webhook API', () => {
+	it('should return errors for rows missing required fields', async () => {
+		const payload = [
+			{
+				title: '', // Missing title
+				description: 'A test description',
+				contact: 'test@example.com'
+			},
+			{
+				title: 'Missing description',
+				description: '', // Missing description
+				contact: 'test@example.com'
+			},
+			{
+				title: 'Missing contact',
+				description: 'A test description',
+				contact: '' // Missing contact
+			},
+			{
+				// Missing everything except an invalid contact field (not even title)
+				contact: 'no-title@example.com'
+			},
+			{
+				title: 'Valid Post',
+				description: 'Valid Description',
+				contact: 'valid@example.com'
+			}
+		];
+
+		const request = new Request('http://localhost/api/webhooks/google-sheets', {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer test_webhook_secret'
+			},
+			body: JSON.stringify(payload)
+		});
+
+		const response = await POST({ request } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data.success).toBe(true);
+		expect(data.insertedCount).toBe(1);
+		expect(data.skippedCount).toBe(0);
+		expect(data.errors).toHaveLength(4);
+
+		expect(data.errors[0]).toEqual({
+			title: '(no title)',
+			error: 'Missing required fields (title, description, or contact)'
+		});
+
+		expect(data.errors[1]).toEqual({
+			title: 'Missing description',
+			error: 'Missing required fields (title, description, or contact)'
+		});
+
+		expect(data.errors[2]).toEqual({
+			title: 'Missing contact',
+			error: 'Missing required fields (title, description, or contact)'
+		});
+
+		expect(data.errors[3]).toEqual({
+			title: '(no title)',
+			error: 'Missing required fields (title, description, or contact)'
+		});
+	});
+});


### PR DESCRIPTION
🎯 **What:** Added a missing edge case test for the Google Sheets webhook (`/api/webhooks/google-sheets/+server.ts`) to ensure it correctly identifies and returns errors for missing required fields (`title`, `description`, or `contact`).

📊 **Coverage:** The new test `server.test.ts` covers scenarios where rows are missing `title`, `description`, `contact`, or completely absent fields, validating the specific error response format.

✨ **Result:** Increased test coverage and confidence that the webhook endpoint correctly validates incoming payloads, preventing bad inserts into the database.

---
*PR created automatically by Jules for task [10544179565677830755](https://jules.google.com/task/10544179565677830755) started by @Sparkier*