### PR TITLE
🧪 test: add missing tests for post creation API endpoint

### DIFF
--- a/src/routes/api/post/server.test.ts
+++ b/src/routes/api/post/server.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from 'vitest';
+import { POST } from './+server';
+
+describe('POST /api/post', () => {
+	it('should throw an error if post DB insertion fails', async () => {
+		const mockSupabase = {
+			from: vi.fn().mockReturnValue({
+				insert: vi.fn().mockReturnValue({
+					select: vi.fn().mockReturnValue({
+						single: vi.fn().mockResolvedValue({
+							data: null,
+							error: new Error('DB Error')
+						})
+					})
+				})
+			})
+		};
+
+		const mockSafeGetSession = vi.fn().mockResolvedValue({
+			session: {
+				user: { email: 'test@example.com' }
+			}
+		});
+
+		const request = {
+			json: vi.fn().mockResolvedValue({
+				title: 'Test',
+				description: 'Desc',
+				contact: 'Contact',
+				industry: 'Tech',
+				education: 'BSc',
+				keywords: []
+			})
+		};
+
+		await expect(
+			POST({
+				locals: {
+					supabase: mockSupabase,
+					safeGetSession: mockSafeGetSession
+				},
+				request
+			} as any)
+		).rejects.toThrow('Failed to create post.');
+	});
+
+	it('should throw an error if post DB insertion succeeds but no data is returned', async () => {
+		const mockSupabase = {
+			from: vi.fn().mockReturnValue({
+				insert: vi.fn().mockReturnValue({
+					select: vi.fn().mockReturnValue({
+						single: vi.fn().mockResolvedValue({
+							data: null,
+							error: null
+						})
+					})
+				})
+			})
+		};
+
+		const mockSafeGetSession = vi.fn().mockResolvedValue({
+			session: {
+				user: { email: 'test@example.com' }
+			}
+		});
+
+		const request = {
+			json: vi.fn().mockResolvedValue({
+				title: 'Test',
+				description: 'Desc',
+				contact: 'Contact',
+				industry: 'Tech',
+				education: 'BSc',
+				keywords: []
+			})
+		};
+
+		await expect(
+			POST({
+				locals: {
+					supabase: mockSupabase,
+					safeGetSession: mockSafeGetSession
+				},
+				request
+			} as any)
+		).rejects.toThrow('Post creation succeeded but no data returned.');
+	});
+
+	it('should successfully create a post', async () => {
+		const mockSupabase = {
+			from: vi.fn().mockImplementation((table) => {
+				if (table === 'post') {
+					return {
+						insert: vi.fn().mockReturnValue({
+							select: vi.fn().mockReturnValue({
+								single: vi.fn().mockResolvedValue({
+									data: { id: 1 },
+									error: null
+								})
+							})
+						})
+					};
+				}
+				if (table === 'postkeyword') {
+					return {
+						insert: vi.fn().mockResolvedValue({
+							error: null
+						})
+					};
+				}
+			})
+		};
+
+		const mockSafeGetSession = vi.fn().mockResolvedValue({
+			session: {
+				user: { email: 'test@example.com' }
+			}
+		});
+
+		const request = {
+			json: vi.fn().mockResolvedValue({
+				title: 'Test',
+				description: 'Desc',
+				contact: 'Contact',
+				industry: 'Tech',
+				education: 'BSc',
+				keywords: ['keyword1']
+			})
+		};
+
+		const response = await POST({
+			locals: {
+				supabase: mockSupabase,
+				safeGetSession: mockSafeGetSession
+			},
+			request
+		} as any);
+
+		expect(response.status).toBe(200);
+	});
+});


### PR DESCRIPTION
🎯 **What:** Adds missing tests to verify correct error handling when a Supabase database insertion fails while creating a post.

📊 **Coverage:**
- Test for `postError` condition when inserting into the DB.
- Test for `!postData` condition when inserting into the DB succeeds but returns no data.
- Test for a successful post creation, covering `postkeyword` associations.

✨ **Result:** Increased test coverage for the post creation endpoint, ensuring that edge cases where database insertions fail or return incorrectly are properly handled.

---
*PR created automatically by Jules for task [7962892363474691278](https://jules.google.com/task/7962892363474691278) started by @Sparkier*