### PR TITLE
🔒 Fix missing rel="noopener noreferrer" in external links

### DIFF
--- a/src/lib/components/Help.svelte
+++ b/src/lib/components/Help.svelte
@@ -4,7 +4,7 @@
 		visPositions is a simiple website that highlights open positions in the VIS/HCI field. Anyone
 		can post on this website, but positions have to be vetted before they're shown to all users. If
 		you want to learn more about visPositions, read
-		<a class="link" href="https://a13x.io/blog/vispositions" target="_blank"> this blogpost </a>.
+		<a class="link" href="https://a13x.io/blog/vispositions" target="_blank" rel="noopener noreferrer"> this blogpost </a>.
 	</p>
 	<h2>Privacy Policy</h2>
 	<p>


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a missing `rel="noopener noreferrer"` attribute on an external link.
⚠️ **Risk:** Without `noopener noreferrer`, the target page can gain access to the original page's `window.opener` object, potentially leading to tabnabbing (phishing) attacks.
🛡️ **Solution:** Added `rel="noopener noreferrer"` to the `<a>` tag with `target="_blank"` in `src/lib/components/Help.svelte` to prevent access to the original window's context.

---
*PR created automatically by Jules for task [9187218400660373487](https://jules.google.com/task/9187218400660373487) started by @Sparkier*