### PR TITLE
🔒 Secure post webhook with authentication

### DIFF
--- a/src/routes/api/webhooks/post/+server.ts
+++ b/src/routes/api/webhooks/post/+server.ts
@@ -1,10 +1,16 @@
-import { ADMIN_EMAIL, FROM_EMAIL, RESEND_API_KEY } from '$env/static/private';
+import { ADMIN_EMAIL, FROM_EMAIL, RESEND_API_KEY, WEBHOOK_SECRET } from '$env/static/private';
 import { json } from '@sveltejs/kit';
 import { Resend } from 'resend';
 
 const resend = new Resend(RESEND_API_KEY);
 
 export async function POST({ request }) {
+	const authHeader = request.headers.get('Authorization');
+
+	if (!authHeader || authHeader !== `Bearer ${WEBHOOK_SECRET}`) {
+		return new Response('Unauthorized', { status: 401 });
+	}
+
 	try {
 		const payload = await request.json();
 

--- a/src/routes/api/webhooks/post/server.test.ts
+++ b/src/routes/api/webhooks/post/server.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { POST } from './+server';
+
+// Mock $env/static/private
+vi.mock('$env/static/private', () => ({
+	RESEND_API_KEY: 'test_api_key',
+	WEBHOOK_SECRET: 'test_secret',
+	FROM_EMAIL: 'test_from@example.com',
+	ADMIN_EMAIL: 'test_admin@example.com'
+}));
+
+// Mock resend
+vi.mock('resend', () => {
+	return {
+		Resend: vi.fn().mockImplementation(function () {
+			return {
+				emails: {
+					send: vi.fn().mockResolvedValue({ error: null })
+				}
+			};
+		})
+	};
+});
+
+describe('Post Webhook API', () => {
+	it('should return 401 if Authorization header is missing', async () => {
+		const request = new Request('http://localhost/api/webhooks/post', {
+			method: 'POST',
+			body: JSON.stringify({ title: 'Test', description: 'Test desc' })
+		});
+
+		const response = await POST({ request } as any);
+
+		expect(response.status).toBe(401);
+		expect(await response.text()).toBe('Unauthorized');
+	});
+
+	it('should return 401 if Authorization header is incorrect', async () => {
+		const request = new Request('http://localhost/api/webhooks/post', {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer wrong_secret'
+			},
+			body: JSON.stringify({ title: 'Test', description: 'Test desc' })
+		});
+
+		const response = await POST({ request } as any);
+
+		expect(response.status).toBe(401);
+		expect(await response.text()).toBe('Unauthorized');
+	});
+
+	it('should return 200 and success: true for valid request with correct auth', async () => {
+		const request = new Request('http://localhost/api/webhooks/post', {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer test_secret'
+			},
+			body: JSON.stringify({ title: 'Test', description: 'Test desc' })
+		});
+
+		const response = await POST({ request } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data).toEqual({ success: true });
+	});
+});


### PR DESCRIPTION
🎯 **What:** Added `WEBHOOK_SECRET` authentication to the `api/webhooks/post` endpoint.
⚠️ **Risk:** Without authentication, anyone could hit the post webhook endpoint and trigger Resend emails being sent to the admin, which could result in spam, quota exhaustion, and abuse.
🛡️ **Solution:** The endpoint now checks the `Authorization` header against the `WEBHOOK_SECRET` environment variable using a Bearer token format, returning `401 Unauthorized` if invalid or missing. Added a unit test suite for the post webhook.

---
*PR created automatically by Jules for task [2570858272722014266](https://jules.google.com/task/2570858272722014266) started by @Sparkier*