### PR TITLE
⚡ perf: fix N+1 query in keyword insertions for webhook

### DIFF
--- a/src/routes/api/webhooks/google-sheets/+server.ts
+++ b/src/routes/api/webhooks/google-sheets/+server.ts
@@ -104,21 +104,27 @@ export const POST = async ({ request }) => {
 					.in('title', keywords);
 
 				const keywordIdsToInsert = [];
+				const newKeywordsToInsert: string[] = [];
 
 				for (const kw of keywords) {
 					const found = existingKeywords?.find((ek) => ek.title.toLowerCase() === kw.toLowerCase());
 					if (found) {
 						keywordIdsToInsert.push(found.id);
 					} else {
-						const { data: newKw, error: kwError } = await supabaseAdmin
-							.from('keyword')
-							.insert({ title: kw })
-							.select()
-							.single();
+						newKeywordsToInsert.push(kw);
+					}
+				}
 
-						if (!kwError && newKw) {
-							keywordIdsToInsert.push(newKw.id);
-						}
+				if (newKeywordsToInsert.length > 0) {
+					const { data: newKws, error: kwError } = await supabaseAdmin
+						.from('keyword')
+						.insert(newKeywordsToInsert.map((kw) => ({ title: kw })))
+						.select();
+
+					if (!kwError && newKws) {
+						keywordIdsToInsert.push(...newKws.map((kw) => kw.id));
+					} else if (kwError) {
+						console.error('Failed to bulk insert keywords:', kwError);
 					}
 				}
 


### PR DESCRIPTION
Fresh reapplication of the change from #31 (which had unresolvable conflicts against current `main`, including a stale `package-lock.json` from before the npm→bun switch).

## What

In the Google Sheets webhook, keyword association previously inserted each new keyword one at a time inside the loop (N+1 queries). This collects all not-yet-existing keywords and performs a **single bulk insert**, then maps the returned ids.

## Verification
- `bun run lint` ✓
- `bun run test` — 26/26 pass ✓
- Behavior unchanged; only the DB round-trips are reduced.

Supersedes #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)