### PR TITLE
feat: engagement boosters — linkable jobs, digest CTAs, hashtags

### DIFF
--- a/src/routes/api/newsletter/daily-digest/+server.ts
+++ b/src/routes/api/newsletter/daily-digest/+server.ts
@@ -50,7 +50,7 @@ export const POST: RequestHandler = async ({ locals: { supabase }, request }) =>
 		const postsText = posts
 			.map(
 				(post) =>
-					`- ${post.title}\n   ${post.description?.substring(0, 100)}...\n   View: ${siteUrl}\n\n`
+					`- ${post.title}\n   ${post.description?.substring(0, 100)}...\n   View: ${siteUrl}/jobs/${post.id}\n\n`
 			)
 			.join('');
 		const linkedinText = posts.map((post) => `- ${post.title}\n`).join('');
@@ -59,20 +59,25 @@ export const POST: RequestHandler = async ({ locals: { supabase }, request }) =>
 				.map((post) => {
 					const safeTitle = escapeHtml(post.title);
 					const safeDesc = post.description ? escapeHtml(post.description.substring(0, 100)) : '';
-					return `<li><a href="${siteUrl}"><strong>${safeTitle}</strong></a><br/>${safeDesc}...</li>`;
+					return `<li><a href="${siteUrl}/jobs/${post.id}"><strong>${safeTitle}</strong></a><br/>${safeDesc}...</li>`;
 				})
 				.join('') + `</ul>`;
 
 		const textBody =
 			`${textBodyHeader}${postsText}` +
 			`Visit ${siteUrl} to see more.\n\n` +
+			`Know someone who'd be a good fit? Forward them this email or share ${siteUrl} — it helps more people find these roles.\n\n` +
 			`To unsubscribe from these emails, click here: {{{RESEND_UNSUBSCRIBE_URL}}}`;
 
-		const linkedInBody = `${textBodyHeader}${linkedinText}\n\nVisit ${siteUrl} to see more.\n\n#job #visualization #dataviz`;
+		const linkedInPs = `PS: This is a side project I maintain in my spare time — now in its second year. If you find it useful, a like or repost genuinely helps more people discover it. 🙏`;
+
+		const linkedInBody = `${textBodyHeader}${linkedinText}\n\nVisit ${siteUrl} to see more.\n\n${linkedInPs}\n\n#dataviz #datavisualization #hiring #datavizjobs #informationdesign`;
 
 		const htmlBody =
 			`${htmlBodyHeader}${postsHtml}` +
 			`<p>Visit <a href="${siteUrl}">${siteUrl}</a> to see more.</p>` +
+			`<p>Know someone who'd be a good fit? Forward them this email or share ` +
+			`<a href="${siteUrl}">${siteUrl}</a> — it helps more people find these roles.</p>` +
 			`<p style="font-size: 0.8em; color: #666;">` +
 			`To unsubscribe, <a href={{{RESEND_UNSUBSCRIBE_URL}}}>click here</a>.` +
 			`</p>`;

--- a/src/routes/jobs/[id]/+page.server.ts
+++ b/src/routes/jobs/[id]/+page.server.ts
@@ -1,0 +1,17 @@
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ params, locals: { supabase } }) => {
+	const { data: post } = await supabase
+		.from('post')
+		.select('*, keyword( id, title )')
+		.eq('id', params.id)
+		.eq('vetted', true)
+		.single();
+
+	if (!post) {
+		throw error(404, 'Position not found');
+	}
+
+	return { post };
+};

--- a/src/routes/jobs/[id]/+page.svelte
+++ b/src/routes/jobs/[id]/+page.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import Post from '$lib/components/Post.svelte';
+	import type { Post as PostType } from '$lib/types';
+
+	let { data } = $props();
+
+	const post: PostType = $derived(data.post);
+
+	const siteUrl = 'https://vispositions.com';
+	const title = $derived(`${post.title} — visPositions`);
+	const description = $derived((post.description ?? '').slice(0, 160));
+	const url = $derived(`${siteUrl}/jobs/${post.id}`);
+</script>
+
+<svelte:head>
+	<title>{title}</title>
+	<meta name="description" content={description} />
+	<meta property="og:type" content="website" />
+	<meta property="og:title" content={title} />
+	<meta property="og:description" content={description} />
+	<meta property="og:url" content={url} />
+	<meta name="twitter:card" content="summary" />
+	<meta name="twitter:title" content={title} />
+	<meta name="twitter:description" content={description} />
+</svelte:head>
+
+<div class="mx-auto flex w-full max-w-3xl flex-col gap-4 overflow-y-auto">
+	<a href="/" class="text-sm text-gray-500 transition-all hover:text-primary">← All positions</a>
+	<Post {post} />
+</div>


### PR DESCRIPTION
Drives engagement/reach for visPositions through a few low-risk levers.

## Changes
- **Individually linkable jobs** — new public `/jobs/[id]` route rendering a single vetted position via the existing `Post` component, with `<title>` + OG/Twitter meta tags so a pasted link shows the role title & description instead of the bare homepage. Expired-but-vetted posts still resolve, so old shared links don't 404.
- **Digest links now per-job** — the daily email links each entry to `/jobs/{id}` instead of the homepage.
- **Newsletter share CTA** — added a "forward this / share vispositions.com" ask to the email (text + HTML). Email equivalent of a repost.
- **LinkedIn PS** — soft, non-guilt-trip "if you find it useful, a like or repost helps" line above the hashtags.
- **Hashtags** — `#job #visualization #dataviz` → `#dataviz #datavisualization #hiring #datavizjobs #informationdesign` (mix of broad reach + niche targeting).

## Notes
- Rebased onto current `origin/main` (local `main` was 25 commits behind) so the recent digest refactor — `FROM_EMAIL`, `escapeHtml`, try/catch around the LinkedIn call — is preserved.
- `svelte-check` reports no errors in the changed/added files. Pre-existing repo errors (missing `vitest` devDep locally, `$env/static/private` members needing a local `.env`) are unrelated and untouched.
- Company @-tagging on LinkedIn was considered and dropped: it needs a company LinkedIn URN we don't store, and name-based lookup isn't reliable.

## Testing
See the checklist in the PR discussion / linked review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)