### PR TITLE
🧪 test: cover db error branch for PATCH post endpoint

### DIFF
--- a/src/routes/api/post/[id]/server.test.ts
+++ b/src/routes/api/post/[id]/server.test.ts
@@ -69,6 +69,42 @@ describe('PATCH /api/post/[id]', () => {
 			} as unknown as Parameters<typeof PATCH>[0])
 		).rejects.toThrow('Invalid education level');
 	});
+
+	it('should throw 500 when database update fails', async () => {
+		const mockSafeGetSession = vi.fn().mockResolvedValue({
+			session: { user: { email: 'test@example.com' } }
+		});
+
+		const request = {
+			json: vi.fn().mockResolvedValue({
+				title: 'Valid Title',
+				description: 'Valid description',
+				contact: 'test@example.com',
+				industry: true,
+				education: 'undergraduate',
+				keywords: []
+			})
+		};
+
+		const mockEq2 = vi.fn().mockResolvedValue({ error: new Error('DB Error') });
+		const mockEq1 = vi.fn().mockReturnValue({ eq: mockEq2 });
+		const mockUpdate = vi.fn().mockReturnValue({ eq: mockEq1 });
+		const mockFrom = vi.fn().mockReturnValue({ update: mockUpdate });
+
+		const mockSupabase = {
+			from: mockFrom
+		};
+
+		await expect(
+			PATCH({
+				locals: { supabase: mockSupabase, safeGetSession: mockSafeGetSession },
+				params: { id: '1' },
+				request
+			} as unknown as Parameters<typeof PATCH>[0])
+		).rejects.toThrow('Internal Server Error');
+
+		expect(error).toHaveBeenCalledWith(500, 'Internal Server Error');
+	});
 });
 
 describe('DELETE /api/post/[id]', () => {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of coverage for the database error branch when a post is updated via a `PATCH` request to `src/routes/api/post/[id]`.

📊 **Coverage:** A new test case is added that mocks a database error during the `update` query and asserts that a `500 Internal Server Error` is correctly thrown.

✨ **Result:** Increased code coverage by testing the failure state of the `update` method, enhancing confidence and reliability.

---
*PR created automatically by Jules for task [14234913883483583683](https://jules.google.com/task/14234913883483583683) started by @Sparkier*