### PR TITLE
🧪 Improve testing coverage for newsletter subscribe API

### DIFF
--- a/src/routes/api/newsletter/subscribe/server.test.ts
+++ b/src/routes/api/newsletter/subscribe/server.test.ts
@@ -120,7 +120,9 @@ describe('Newsletter Subscribe API', () => {
 			body: JSON.stringify({ email: 'valid@example.com' })
 		});
 
-		await expect(POST({ request } as unknown as Parameters<typeof POST>[0])).rejects.toThrow('Failed to subscribe.');
+		await expect(POST({ request } as unknown as Parameters<typeof POST>[0])).rejects.toThrow(
+			'Failed to subscribe.'
+		);
 		expect(error).toHaveBeenCalledWith(500, 'Failed to subscribe.');
 	});
 });

--- a/src/routes/api/newsletter/subscribe/server.test.ts
+++ b/src/routes/api/newsletter/subscribe/server.test.ts
@@ -1,10 +1,28 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from './+server';
+import { error } from '@sveltejs/kit';
+
+const mocks = vi.hoisted(() => ({
+	create: vi.fn().mockResolvedValue({ error: null })
+}));
 
 // Mock $env/static/private
 vi.mock('$env/static/private', () => ({
 	RESEND_API_KEY: 'test_api_key',
 	RESEND_AUDIENCE_ID: 'test_audience_id'
+}));
+
+// Mock @sveltejs/kit
+vi.mock('@sveltejs/kit', () => ({
+	error: vi.fn((status, message) => {
+		const err = new Error(message);
+		(err as Error & { status: number }).status = status;
+		return err;
+	}),
+	json: vi.fn((data, init) => {
+		const status = init?.status || 200;
+		return new Response(JSON.stringify(data), { status });
+	})
 }));
 
 // Mock resend
@@ -13,7 +31,7 @@ vi.mock('resend', () => {
 		Resend: vi.fn().mockImplementation(function () {
 			return {
 				contacts: {
-					create: vi.fn().mockResolvedValue({ error: null })
+					create: mocks.create
 				}
 			};
 		})
@@ -21,6 +39,11 @@ vi.mock('resend', () => {
 });
 
 describe('Newsletter Subscribe API', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.create.mockResolvedValue({ error: null });
+	});
+
 	it('should return 400 for missing email', async () => {
 		const request = new Request('http://localhost/api/newsletter/subscribe', {
 			method: 'POST',
@@ -67,5 +90,37 @@ describe('Newsletter Subscribe API', () => {
 			success: false,
 			message: 'Invalid email address provided.'
 		});
+	});
+
+	it('should return 200 on successful subscription', async () => {
+		const request = new Request('http://localhost/api/newsletter/subscribe', {
+			method: 'POST',
+			body: JSON.stringify({ email: 'valid@example.com' })
+		});
+
+		const response = await POST({ request } as unknown as Parameters<typeof POST>[0]);
+		const data = await response.json();
+
+		expect(mocks.create).toHaveBeenCalledWith({
+			email: 'valid@example.com',
+			audienceId: 'test_audience_id'
+		});
+		expect(response.status).toBe(200);
+		expect(data).toEqual({
+			success: true,
+			message: 'Successfully subscribed!'
+		});
+	});
+
+	it('should throw a 500 error if resend API returns an error', async () => {
+		mocks.create.mockResolvedValue({ error: { message: 'Some resend error' } });
+
+		const request = new Request('http://localhost/api/newsletter/subscribe', {
+			method: 'POST',
+			body: JSON.stringify({ email: 'valid@example.com' })
+		});
+
+		await expect(POST({ request } as unknown as Parameters<typeof POST>[0])).rejects.toThrow('Failed to subscribe.');
+		expect(error).toHaveBeenCalledWith(500, 'Failed to subscribe.');
 	});
 });


### PR DESCRIPTION
🎯 **What:** Improved test coverage for the newsletter subscription API endpoint (`src/routes/api/newsletter/subscribe/+server.ts`). Specifically added tests to cover the path where the Resend API encounters an error, and the happy path for a successful subscription.

📊 **Coverage:**
- Added test to verify a 200 response on a successful subscription.
- Added test to verify a 500 error is thrown when `resend.contacts.create` returns an error object.

✨ **Result:** Enhanced the reliability of the `POST` endpoint by covering critical success and error paths, thereby increasing overall test suite coverage.

---
*PR created automatically by Jules for task [15539446380363614320](https://jules.google.com/task/15539446380363614320) started by @Sparkier*