### PR TITLE
🔒 Fix IDOR vulnerability in post updates

### DIFF
--- a/src/routes/api/post/[id]/+server.ts
+++ b/src/routes/api/post/[id]/+server.ts
@@ -87,14 +87,19 @@ export const PATCH = async ({ locals: { supabase, safeGetSession }, params, requ
 		expiration_date: data.expiration_date
 	};
 
-	const { error: postError } = await supabase
+	const { data: updatedPost, error: postError } = await supabase
 		.from('post')
 		.update(updateData)
 		.eq('id', params.id)
-		.eq('creator', session.user.email);
+		.eq('creator', session.user.email)
+		.select();
 
 	if (postError) {
 		throw error(500, 'Internal Server Error');
+	}
+
+	if (!updatedPost || updatedPost.length === 0) {
+		throw error(404, 'Not found or unauthorized');
 	}
 
 	// Delete existing keyword associations

--- a/src/routes/api/post/[id]/server.test.ts
+++ b/src/routes/api/post/[id]/server.test.ts
@@ -69,6 +69,57 @@ describe('PATCH /api/post/[id]', () => {
 			} as unknown as Parameters<typeof PATCH>[0])
 		).rejects.toThrow('Invalid education level');
 	});
+	it('should throw 404 when updating a non-existent post or unauthorized post', async () => {
+		const mockSelect = vi.fn().mockResolvedValue({ data: [] });
+		const mockEq2 = vi.fn().mockReturnValue({ select: mockSelect });
+		const mockEq1 = vi.fn().mockReturnValue({ eq: mockEq2 });
+		const mockUpdate = vi.fn().mockReturnValue({ eq: mockEq1 });
+		const mockFrom = vi.fn().mockReturnValue({ update: mockUpdate });
+
+		const mockSupabase = {
+			from: mockFrom
+		};
+
+		const mockSafeGetSession = vi.fn().mockResolvedValue({
+			session: {
+				user: {
+					email: 'test@example.com'
+				}
+			}
+		});
+
+		const locals = {
+			supabase: mockSupabase,
+			safeGetSession: mockSafeGetSession
+		};
+
+		const params = {
+			id: 'non-existent-id'
+		};
+
+		const request = {
+			json: vi.fn().mockResolvedValue({
+				title: 'Valid Title',
+				description: 'Valid description',
+				contact: 'Valid contact',
+				industry: true,
+				education: 'none',
+				keywords: [],
+				expiration_date: '2025-01-01'
+			})
+		};
+
+		await expect(
+			PATCH({
+				locals,
+				params,
+				request
+			} as unknown as Parameters<typeof PATCH>[0])
+		).rejects.toThrow('Not found or unauthorized');
+
+		// Verify that error was called with 404
+		expect(error).toHaveBeenCalledWith(404, 'Not found or unauthorized');
+	});
 });
 
 describe('DELETE /api/post/[id]', () => {


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Fixed an Insecure Direct Object Reference (IDOR) on the `PATCH /api/post/[id]` route where a user could modify keywords of a post they do not own.

⚠️ **Risk:** The potential impact if left unfixed
Previously, the code only checked for a database `error` from Supabase on update, but without `.select()`, Supabase returns success even if no rows match the filter `id = params.id` and `creator = session.user.email`. This allowed unauthorized users to proceed past the check, resulting in the endpoint deleting and re-inserting keywords for posts they did not own, which is a major security flaw.

🛡️ **Solution:** How the fix addresses the vulnerability
Appended `.select()` to the Supabase `update` query and checked the returned `data` payload. If it is null or empty, it throws a `404 Not found or unauthorized` error, preventing the execution from reaching the subsequent keyword deletion/insertion logic. Also added a comprehensive test to verify this behavior correctly blocks unowned post modifications.

---
*PR created automatically by Jules for task [17914967494521786957](https://jules.google.com/task/17914967494521786957) started by @Sparkier*