### PR TITLE
🧪 [test] add coverage for unauthorized post deletion

### DIFF
--- a/src/routes/api/post/[id]/server.test.ts
+++ b/src/routes/api/post/[id]/server.test.ts
@@ -72,6 +72,26 @@ describe('PATCH /api/post/[id]', () => {
 });
 
 describe('DELETE /api/post/[id]', () => {
+	it('should throw 401 when deleting a post without a session', async () => {
+		const mockSafeGetSession = vi.fn().mockResolvedValue({
+			session: null
+		});
+
+		const locals = {
+			safeGetSession: mockSafeGetSession
+		};
+
+		const params = {
+			id: 'some-id'
+		};
+
+		await expect(
+			DELETE({ locals, params } as unknown as Parameters<typeof DELETE>[0])
+		).rejects.toThrow('Unauthorized');
+
+		expect(error).toHaveBeenCalledWith(401, 'Unauthorized');
+	});
+
 	it('should throw 404 when deleting a non-existent post', async () => {
 		// Create a mock chain for supabase
 		const mockEq2 = vi.fn().mockResolvedValue({ data: [] });


### PR DESCRIPTION
🎯 **What:** Added a test case to cover the scenario where a user attempts to delete a post without an active session (i.e., `safeGetSession` returns `null`).
📊 **Coverage:** The test ensures that the `DELETE /api/post/[id]` endpoint correctly intercepts unauthorized requests and throws a 401 error.
✨ **Result:** Improved test coverage and guaranteed that the endpoint's initial authentication check behaves as expected.

---
*PR created automatically by Jules for task [15202257678997556827](https://jules.google.com/task/15202257678997556827) started by @Sparkier*