### PR TITLE
🧪 [Testing Improvement] Add test suite for `getDefaultExpirationDate`

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,47 @@
-import { describe, it, expect } from 'vitest';
-import { escapeHtml } from './utils';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { escapeHtml, getDefaultExpirationDate } from './utils';
+
+describe('getDefaultExpirationDate', () => {
+	beforeAll(() => {
+		vi.useFakeTimers();
+	});
+
+	afterAll(() => {
+		vi.useRealTimers();
+	});
+
+	it('adds 3 months by default', () => {
+		vi.setSystemTime(new Date('2024-01-15T12:00:00Z'));
+		const result = getDefaultExpirationDate();
+		expect(result.getFullYear()).toBe(2024);
+		expect(result.getMonth()).toBe(3); // 0-indexed, so 3 is April
+		expect(result.getDate()).toBe(15);
+	});
+
+	it('adds specified number of months', () => {
+		vi.setSystemTime(new Date('2024-01-15T12:00:00Z'));
+		const result = getDefaultExpirationDate(6);
+		expect(result.getFullYear()).toBe(2024);
+		expect(result.getMonth()).toBe(6); // 6 is July
+		expect(result.getDate()).toBe(15);
+	});
+
+	it('handles crossing year boundary', () => {
+		vi.setSystemTime(new Date('2024-11-15T12:00:00Z'));
+		const result = getDefaultExpirationDate(3);
+		expect(result.getFullYear()).toBe(2025);
+		expect(result.getMonth()).toBe(1); // 1 is February
+		expect(result.getDate()).toBe(15);
+	});
+
+	it('handles negative months', () => {
+		vi.setSystemTime(new Date('2024-05-15T12:00:00Z'));
+		const result = getDefaultExpirationDate(-2);
+		expect(result.getFullYear()).toBe(2024);
+		expect(result.getMonth()).toBe(2); // 2 is March
+		expect(result.getDate()).toBe(15);
+	});
+});
 
 describe('escapeHtml', () => {
 	it('escapes & to &amp;', () => {


### PR DESCRIPTION
🎯 **What:** The testing gap for the `getDefaultExpirationDate` utility function in `src/lib/utils.ts` has been addressed.
📊 **Coverage:** The new tests cover scenarios including default usage (adds 3 months), specific numeric increments, crossing year boundaries, and handling negative inputs using deterministic time tracking via Vitest fake timers.
✨ **Result:** Test coverage for `src/lib/utils.ts` has improved, reducing the risk of time-related regressions, and all tests in the suite successfully pass.

---
*PR created automatically by Jules for task [15273453088898430038](https://jules.google.com/task/15273453088898430038) started by @Sparkier*