### PR TITLE
🧪 [Testing] Add test for unauthorized post creation

### DIFF
--- a/src/routes/api/post/server.test.ts
+++ b/src/routes/api/post/server.test.ts
@@ -2,6 +2,19 @@ import { describe, it, expect, vi } from 'vitest';
 import { POST } from './+server';
 
 describe('POST /api/post', () => {
+	it('should throw a 401 error if session is null (unauthorized)', async () => {
+		const mockSafeGetSession = vi.fn().mockResolvedValue({
+			session: null
+		});
+
+		await expect(
+			POST({
+				locals: { safeGetSession: mockSafeGetSession },
+				request: {}
+			} as unknown as Parameters<typeof POST>[0])
+		).rejects.toMatchObject({ status: 401, body: { message: 'Unauthorized' } });
+	});
+
 	it('should throw a 400 error if title is missing or invalid', async () => {
 		const mockSafeGetSession = vi.fn().mockResolvedValue({
 			session: { user: { email: 'test@example.com' } }


### PR DESCRIPTION
🎯 **What:** Added a unit test to `src/routes/api/post/server.test.ts` to verify the 401 Unauthorized error handling when a post is created with a null session.
📊 **Coverage:** The test mocks `safeGetSession` to return `null` and validates that the `POST` handler rejects with a 401 status and the correct error message.
✨ **Result:** Improved test coverage for the API's authentication flow, ensuring that unauthorized post creation correctly throws an error.

---
*PR created automatically by Jules for task [1404586882410020216](https://jules.google.com/task/1404586882410020216) started by @Sparkier*