### PR TITLE
🧪 [testing improvement] Test safeGetSession with no session

### DIFF
--- a/src/hooks.server.test.ts
+++ b/src/hooks.server.test.ts
@@ -1,6 +1,42 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { RequestEvent } from '@sveltejs/kit';
-import { authGuard } from './hooks.server';
+import { authGuard, supabase } from './hooks.server';
+
+vi.mock('$env/static/public', () => ({
+	PUBLIC_SUPABASE_URL: 'https://test.supabase.co',
+	PUBLIC_SUPABASE_ANON_KEY: 'test-anon-key'
+}));
+
+vi.mock('@supabase/ssr', () => ({
+	createServerClient: vi.fn().mockImplementation(() => {
+		return {
+			auth: {
+				getSession: vi.fn().mockResolvedValue({ data: { session: null } })
+			}
+		};
+	})
+}));
+
+describe('supabase middleware', () => {
+	it('safeGetSession returns { session: null, user: null } when no session is found', async () => {
+		const resolve = vi.fn().mockResolvedValue(new Response());
+
+		const mockCookies = {
+			getAll: vi.fn().mockReturnValue([]),
+			set: vi.fn()
+		};
+
+		const event = {
+			locals: {},
+			cookies: mockCookies
+		} as unknown as RequestEvent;
+
+		await supabase({ event, resolve });
+
+		const result = await event.locals.safeGetSession();
+		expect(result).toEqual({ session: null, user: null });
+	});
+});
 
 describe('authGuard middleware', () => {
 	it('redirects unauthenticated users from private paths to /auth', async () => {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -4,7 +4,7 @@ import { sequence } from '@sveltejs/kit/hooks';
 
 import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '$env/static/public';
 
-const supabase: Handle = async ({ event, resolve }) => {
+export const supabase: Handle = async ({ event, resolve }) => {
 	/**
 	 * Creates a Supabase client specific to this server request.
 	 *


### PR DESCRIPTION
🎯 **What:** Added a missing unit test to `src/hooks.server.test.ts` to verify the behavior of `safeGetSession` inside the SvelteKit `supabase` middleware when no session is present.
📊 **Coverage:** Mocked `$env/static/public` and `@supabase/ssr` to simulate Supabase `getSession` returning `null`. Asserted that `safeGetSession` correctly falls back to returning `{ session: null, user: null }`.
✨ **Result:** Improved test coverage and reliability for the SvelteKit application's server hooks and authentication guard rails.

---
*PR created automatically by Jules for task [16594490157653392721](https://jules.google.com/task/16594490157653392721) started by @Sparkier*