### PR TITLE
🧪 test: improve coverage for safeGetSession in hooks.server.ts

### DIFF
--- a/src/hooks.server.test.ts
+++ b/src/hooks.server.test.ts
@@ -14,17 +14,20 @@ vi.mock('$env/static/public', () => ({
 
 import type { Mock } from 'vitest';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyMock = Mock<(...args: any[]) => any>;
+
 describe('supabase middleware', () => {
 	let event: RequestEvent;
-	let resolve: Mock<[event: RequestEvent], Promise<Response>>;
-	let mockGetSession: Mock;
-	let mockGetUser: Mock;
+	let resolve: AnyMock;
+	let mockGetSession: AnyMock;
+	let mockGetUser: AnyMock;
 
 	beforeEach(() => {
 		mockGetSession = vi.fn();
 		mockGetUser = vi.fn();
 
-		(createServerClient as unknown as Mock).mockReturnValue({
+		(createServerClient as unknown as AnyMock).mockReturnValue({
 			auth: {
 				getSession: mockGetSession,
 				getUser: mockGetUser

--- a/src/hooks.server.test.ts
+++ b/src/hooks.server.test.ts
@@ -1,6 +1,80 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { RequestEvent } from '@sveltejs/kit';
-import { authGuard } from './hooks.server';
+import { authGuard, supabase } from './hooks.server';
+import { createServerClient } from '@supabase/ssr';
+
+vi.mock('@supabase/ssr', () => ({
+	createServerClient: vi.fn()
+}));
+
+vi.mock('$env/static/public', () => ({
+	PUBLIC_SUPABASE_URL: 'https://test.supabase.co',
+	PUBLIC_SUPABASE_ANON_KEY: 'test-anon-key'
+}));
+
+import type { Mock } from 'vitest';
+
+describe('supabase middleware', () => {
+	let event: RequestEvent;
+	let resolve: Mock<[event: RequestEvent], Promise<Response>>;
+	let mockGetSession: Mock;
+	let mockGetUser: Mock;
+
+	beforeEach(() => {
+		mockGetSession = vi.fn();
+		mockGetUser = vi.fn();
+
+		(createServerClient as unknown as Mock).mockReturnValue({
+			auth: {
+				getSession: mockGetSession,
+				getUser: mockGetUser
+			}
+		});
+
+		event = {
+			locals: {},
+			cookies: {
+				getAll: vi.fn(),
+				set: vi.fn()
+			}
+		} as unknown as RequestEvent;
+		resolve = vi.fn().mockResolvedValue('resolved');
+	});
+
+	it('returns null session and user if getSession returns no session', async () => {
+		mockGetSession.mockResolvedValue({ data: { session: null } });
+
+		await supabase({ event, resolve });
+		const result = await event.locals.safeGetSession();
+
+		expect(result).toEqual({ session: null, user: null });
+		expect(mockGetUser).not.toHaveBeenCalled();
+	});
+
+	it('returns null session and user if getSession returns a session but getUser returns an error', async () => {
+		mockGetSession.mockResolvedValue({ data: { session: { id: 'test_session' } } });
+		mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('Invalid token') });
+
+		await supabase({ event, resolve });
+		const result = await event.locals.safeGetSession();
+
+		expect(result).toEqual({ session: null, user: null });
+		expect(mockGetUser).toHaveBeenCalled();
+	});
+
+	it('returns session and user if both getSession and getUser succeed', async () => {
+		const session = { id: 'test_session' };
+		const user = { id: 'test_user' };
+		mockGetSession.mockResolvedValue({ data: { session } });
+		mockGetUser.mockResolvedValue({ data: { user }, error: null });
+
+		await supabase({ event, resolve });
+		const result = await event.locals.safeGetSession();
+
+		expect(result).toEqual({ session, user });
+		expect(mockGetUser).toHaveBeenCalled();
+	});
+});
 
 describe('authGuard middleware', () => {
 	it('redirects unauthenticated users from private paths to /auth', async () => {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -4,7 +4,7 @@ import { sequence } from '@sveltejs/kit/hooks';
 
 import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '$env/static/public';
 
-const supabase: Handle = async ({ event, resolve }) => {
+export const supabase: Handle = async ({ event, resolve }) => {
 	/**
 	 * Creates a Supabase client specific to this server request.
 	 *


### PR DESCRIPTION
🎯 **What:** Added tests for the `safeGetSession` function within the `supabase` middleware in `src/hooks.server.ts` to explicitly handle the edge case where `getSession` succeeds but `getUser` fails, indicating an invalid JWT token. To enable this, the `supabase` handler function was exported for testability.

📊 **Coverage:**
- Added test coverage verifying `session: null, user: null` is returned when `getSession` finds no session.
- Added test coverage verifying `session: null, user: null` is returned when `getSession` successfully retrieves a session but `getUser` throws an error (JWT invalidation).
- Added happy path coverage when both `getSession` and `getUser` succeed.

✨ **Result:** Enhanced test reliability and coverage, ensuring that unauthenticated access scenarios are properly verified and protected against future regressions.

---
*PR created automatically by Jules for task [826373049521642647](https://jules.google.com/task/826373049521642647) started by @Sparkier*