### PR TITLE
🔒 Fix TOCTOU vulnerability in post deletion

### DIFF
--- a/src/routes/api/post/[id]/+server.ts
+++ b/src/routes/api/post/[id]/+server.ts
@@ -7,19 +7,19 @@ export const DELETE = async ({ locals: { supabase, safeGetSession }, params }) =
 		throw error(401, 'Unauthorized');
 	}
 
-	const { data: posts } = await supabase
+	const { error: deleteError, data } = await supabase
 		.from('post')
-		.select()
+		.delete()
 		.eq('id', params.id)
-		.eq('creator', session.user.email);
-	if (!posts?.length) {
-		throw error(404, 'Not found or unauthorized');
-	}
-
-	const { error: deleteError } = await supabase.from('post').delete().eq('id', params.id);
+		.eq('creator', session.user.email)
+		.select();
 
 	if (deleteError) {
 		throw error(500, 'Internal Server Error');
+	}
+
+	if (!data?.length) {
+		throw error(404, 'Not found or unauthorized');
 	}
 
 	return text('Post deleted');

--- a/src/routes/api/post/[id]/server.test.ts
+++ b/src/routes/api/post/[id]/server.test.ts
@@ -74,10 +74,11 @@ describe('PATCH /api/post/[id]', () => {
 describe('DELETE /api/post/[id]', () => {
 	it('should throw 404 when deleting a non-existent post', async () => {
 		// Create a mock chain for supabase
-		const mockEq2 = vi.fn().mockResolvedValue({ data: [] });
+		const mockSelect = vi.fn().mockResolvedValue({ data: [], error: null });
+		const mockEq2 = vi.fn().mockReturnValue({ select: mockSelect });
 		const mockEq1 = vi.fn().mockReturnValue({ eq: mockEq2 });
-		const mockSelect = vi.fn().mockReturnValue({ eq: mockEq1 });
-		const mockFrom = vi.fn().mockReturnValue({ select: mockSelect });
+		const mockDelete = vi.fn().mockReturnValue({ eq: mockEq1 });
+		const mockFrom = vi.fn().mockReturnValue({ delete: mockDelete });
 
 		const mockSupabase = {
 			from: mockFrom


### PR DESCRIPTION
🎯 **What:** Addressed a Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability in the post deletion endpoint (`src/routes/api/post/[id]/+server.ts`).
⚠️ **Risk:** Previously, the existence and ownership check was performed separately from the actual deletion operation, exposing a race condition that could be exploited.
🛡️ **Solution:** Consolidated the check and deletion queries into a single atomic `.delete().eq().eq().select()` query to ensure they happen in one database operation. Tests in `src/routes/api/post/[id]/server.test.ts` were updated to match the new atomic query structure.

### 📊 Coverage
Modified the test mock to accurately reflect the consolidated delete operation. All 44 tests continue to pass successfully.

### ✨ Result
The API deletion endpoint is now atomic and no longer susceptible to race condition vulnerabilities.

---
*PR created automatically by Jules for task [6478881251461013849](https://jules.google.com/task/6478881251461013849) started by @Sparkier*