### PR TITLE
🧹 Use consistent `import type` syntax for Snippet in Popup.svelte

### DIFF
--- a/src/lib/components/ui/Popup.svelte
+++ b/src/lib/components/ui/Popup.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import type { KeyboardEventHandler, MouseEventHandler } from 'svelte/elements';
 	import { fade } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -9,7 +10,7 @@
 		onkeydown,
 		class: classNames = ''
 	}: {
-		children: import('svelte').Snippet;
+		children: Snippet;
 		onclose: MouseEventHandler<HTMLDivElement>;
 		onkeydown?: KeyboardEventHandler<Window>;
 		class?: string;

--- a/src/lib/components/ui/Popup.svelte
+++ b/src/lib/components/ui/Popup.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { type Snippet } from 'svelte';
 	import type { KeyboardEventHandler, MouseEventHandler } from 'svelte/elements';
 	import { fade } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -10,7 +9,7 @@
 		onkeydown,
 		class: classNames = ''
 	}: {
-		children: Snippet;
+		children: import('svelte').Snippet;
 		onclose: MouseEventHandler<HTMLDivElement>;
 		onkeydown?: KeyboardEventHandler<Window>;
 		class?: string;


### PR DESCRIPTION
🎯 **What**

Original premise was wrong: the `Snippet` import in `src/lib/components/ui/Popup.svelte` was **not** unused — it is referenced by the `children` prop type. The first commit replaced it with an inline `import('svelte').Snippet`, which is the escape-hatch form (for JSDoc / ambient declarations) and made `Popup.svelte` inconsistent with `Button.svelte` right next to it.

This PR now does the minimal, actually-useful change instead:

```diff
-	import { type Snippet } from 'svelte';
+	import type { Snippet } from 'svelte';
```

That is exactly the form `src/lib/components/ui/Button.svelte` already uses, so both UI components declare the prop the same way. It also avoids the value-import-with-inline-type-specifier syntax that presumably produced the false "unused import" report.

📊 **Coverage**

- `bun run lint` — passes (prettier + eslint clean)
- `bun run test` — 44 tests / 10 files, all passing
- `bun run check` — no errors in `Popup.svelte`; the 21 reported errors are pre-existing `$env/static/*` missing-variable errors in API routes, unrelated to this change

✨ **Result**

Net diff against `main` is a single-token change. No behaviour change, type safety preserved, and the two `ui/` components are now consistent.

---
*Originally opened automatically by Jules for task [12309189651552194086](https://jules.google.com/task/12309189651552194086); scope corrected after review.*