### PR TITLE
🔗 Self-service LinkedIn token renewal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           echo "WEBHOOK_SECRET=dummy" >> .env
           echo "FROM_EMAIL=from@example.com" >> .env
           echo "LINKEDIN_ORGANIZATION_ID=dummy" >> .env
+          echo "LINKEDIN_CLIENT_ID=dummy" >> .env
+          echo "LINKEDIN_CLIENT_SECRET=dummy" >> .env
           echo "RESEND_AUDIENCE_ID=dummy" >> .env
           echo "SUPABASE_SERVICE_ROLE_KEY=dummy" >> .env
 

--- a/src/lib/server/linkedin.test.ts
+++ b/src/lib/server/linkedin.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('$env/static/private', () => ({
+	LINKEDIN_CLIENT_ID: 'test_client_id',
+	LINKEDIN_CLIENT_SECRET: 'test_client_secret',
+	SUPABASE_SERVICE_ROLE_KEY: 'test_service_role_key'
+}));
+
+vi.mock('$env/dynamic/private', () => ({
+	env: { LINKEDIN_ACCESS_TOKEN: 'env_fallback_token' }
+}));
+
+vi.mock('$env/static/public', () => ({
+	PUBLIC_SUPABASE_URL: 'http://localhost:54321'
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+	createClient: vi.fn(() => ({ from: vi.fn() }))
+}));
+
+import {
+	buildAuthUrl,
+	exchangeCode,
+	expiresAtFrom,
+	getAccessToken,
+	getRedirectUri,
+	statusFromRow,
+	EXPIRY_WARNING_DAYS,
+	LINKEDIN_SCOPE,
+	SITE_URL,
+	type LinkedInTokenRow
+} from './linkedin';
+
+const NOW = new Date('2026-08-01T12:00:00.000Z');
+
+function rowExpiringInDays(days: number): LinkedInTokenRow {
+	return {
+		access_token: 'stored_token',
+		expires_at: new Date(NOW.getTime() + days * 24 * 60 * 60 * 1000).toISOString(),
+		updated_at: NOW.toISOString()
+	};
+}
+
+describe('buildAuthUrl', () => {
+	it('includes the client id, scope, state and callback for the given origin', () => {
+		const url = new URL(buildAuthUrl('abc123', 'http://localhost:5173'));
+
+		expect(url.origin + url.pathname).toBe('https://www.linkedin.com/oauth/v2/authorization');
+		expect(url.searchParams.get('response_type')).toBe('code');
+		expect(url.searchParams.get('client_id')).toBe('test_client_id');
+		expect(url.searchParams.get('state')).toBe('abc123');
+		expect(url.searchParams.get('scope')).toBe(LINKEDIN_SCOPE);
+		expect(url.searchParams.get('redirect_uri')).toBe(
+			'http://localhost:5173/api/linkedin/callback'
+		);
+	});
+
+	it('falls back to the production origin', () => {
+		expect(getRedirectUri()).toBe(`${SITE_URL}/api/linkedin/callback`);
+	});
+});
+
+describe('expiresAtFrom', () => {
+	it('turns the expires_in seconds into an absolute timestamp', () => {
+		// LinkedIn's 60-day access token.
+		expect(expiresAtFrom(5184000, NOW).toISOString()).toBe('2026-09-30T12:00:00.000Z');
+	});
+});
+
+describe('statusFromRow', () => {
+	it('reports a healthy token as not needing renewal', () => {
+		const status = statusFromRow(rowExpiringInDays(45), NOW);
+
+		expect(status.daysUntilExpiry).toBe(45);
+		expect(status.expired).toBe(false);
+		expect(status.needsRenewal).toBe(false);
+	});
+
+	it('needs renewal exactly at the warning boundary', () => {
+		expect(statusFromRow(rowExpiringInDays(EXPIRY_WARNING_DAYS), NOW).needsRenewal).toBe(true);
+		expect(statusFromRow(rowExpiringInDays(EXPIRY_WARNING_DAYS + 1), NOW).needsRenewal).toBe(false);
+	});
+
+	it('flags an expired token', () => {
+		const status = statusFromRow(rowExpiringInDays(-1), NOW);
+
+		expect(status.expired).toBe(true);
+		expect(status.needsRenewal).toBe(true);
+	});
+
+	it('stays quiet when no token is stored yet, since the env fallback is in play', () => {
+		const status = statusFromRow(null, NOW);
+
+		expect(status.row).toBeNull();
+		expect(status.daysUntilExpiry).toBeNull();
+		expect(status.needsRenewal).toBe(false);
+	});
+});
+
+describe('getAccessToken', () => {
+	it('prefers the stored token', () => {
+		expect(getAccessToken(statusFromRow(rowExpiringInDays(30), NOW))).toBe('stored_token');
+	});
+
+	it('falls back to the env var before the first reconnect', () => {
+		expect(getAccessToken(statusFromRow(null, NOW))).toBe('env_fallback_token');
+	});
+});
+
+describe('exchangeCode', () => {
+	beforeEach(() => {
+		vi.stubGlobal('fetch', vi.fn());
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('posts the code with the client credentials and returns the token', async () => {
+		vi.mocked(fetch).mockResolvedValue(
+			new Response(JSON.stringify({ access_token: 'fresh_token', expires_in: 5184000 }), {
+				status: 200
+			})
+		);
+
+		const token = await exchangeCode('the_code', 'http://localhost:5173');
+
+		expect(token).toEqual({ access_token: 'fresh_token', expires_in: 5184000 });
+
+		const [url, init] = vi.mocked(fetch).mock.calls[0];
+		expect(url).toBe('https://www.linkedin.com/oauth/v2/accessToken');
+		const body = init?.body as URLSearchParams;
+		expect(body.get('grant_type')).toBe('authorization_code');
+		expect(body.get('code')).toBe('the_code');
+		expect(body.get('client_secret')).toBe('test_client_secret');
+		expect(body.get('redirect_uri')).toBe('http://localhost:5173/api/linkedin/callback');
+	});
+
+	it('throws when LinkedIn rejects the exchange', async () => {
+		vi.mocked(fetch).mockResolvedValue(
+			new Response('{"error":"invalid_request"}', { status: 400 })
+		);
+
+		await expect(exchangeCode('bad_code')).rejects.toThrow('LinkedIn token exchange failed (400)');
+	});
+
+	it('throws when the response is missing the token', async () => {
+		vi.mocked(fetch).mockResolvedValue(
+			new Response(JSON.stringify({ scope: 'x' }), { status: 200 })
+		);
+
+		await expect(exchangeCode('the_code')).rejects.toThrow('unexpected payload');
+	});
+});

--- a/src/lib/server/linkedin.ts
+++ b/src/lib/server/linkedin.ts
@@ -1,0 +1,173 @@
+import {
+	LINKEDIN_CLIENT_ID,
+	LINKEDIN_CLIENT_SECRET,
+	SUPABASE_SERVICE_ROLE_KEY
+} from '$env/static/private';
+// Read dynamically so `LINKEDIN_ACCESS_TOKEN` can be deleted from Vercel after
+// the first reconnect without breaking the build.
+import { env } from '$env/dynamic/private';
+import { PUBLIC_SUPABASE_URL } from '$env/static/public';
+import { createClient } from '@supabase/supabase-js';
+
+// The token row is protected by RLS with no policies, so only the service role
+// can read or write it.
+const supabaseAdmin = createClient(PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+export const SITE_URL = 'https://vispositions.com';
+
+/** Scope the LinkedIn app is approved for. Posting to the org page needs this one. */
+export const LINKEDIN_SCOPE = 'w_organization_social';
+
+/** Warn this many days before the access token expires. */
+export const EXPIRY_WARNING_DAYS = 7;
+
+/** Ties the OAuth callback back to the admin-initiated flow. */
+export const STATE_COOKIE = 'linkedin_oauth_state';
+
+const AUTHORIZATION_URL = 'https://www.linkedin.com/oauth/v2/authorization';
+const ACCESS_TOKEN_URL = 'https://www.linkedin.com/oauth/v2/accessToken';
+
+const TOKEN_ROW_ID = 1;
+
+export type LinkedInTokenRow = {
+	access_token: string;
+	expires_at: string;
+	updated_at: string;
+};
+
+export type TokenStatus = {
+	/** Null when no token has been stored yet — see `getAccessToken`. */
+	row: LinkedInTokenRow | null;
+	/** Days until expiry, rounded down. Null when there is no stored token. */
+	daysUntilExpiry: number | null;
+	expired: boolean;
+	/** True when a stored token is expired or inside the warning window. */
+	needsRenewal: boolean;
+};
+
+export function getRedirectUri(origin: string = SITE_URL): string {
+	return `${origin}/api/linkedin/callback`;
+}
+
+export function getReconnectUrl(origin: string = SITE_URL): string {
+	return `${origin}/private/linkedin`;
+}
+
+export function buildAuthUrl(state: string, origin: string = SITE_URL): string {
+	const params = new URLSearchParams({
+		response_type: 'code',
+		client_id: LINKEDIN_CLIENT_ID,
+		redirect_uri: getRedirectUri(origin),
+		state,
+		scope: LINKEDIN_SCOPE
+	});
+	return `${AUTHORIZATION_URL}?${params.toString()}`;
+}
+
+type AccessTokenResponse = {
+	access_token: string;
+	expires_in: number;
+};
+
+/**
+ * Trades an authorization code for an access token. LinkedIn only issues
+ * refresh tokens to approved Marketing Developer Platform partners, so the
+ * response here is expected to carry just a 60-day access token.
+ */
+export async function exchangeCode(
+	code: string,
+	origin: string = SITE_URL
+): Promise<AccessTokenResponse> {
+	const res = await fetch(ACCESS_TOKEN_URL, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: new URLSearchParams({
+			grant_type: 'authorization_code',
+			code,
+			redirect_uri: getRedirectUri(origin),
+			client_id: LINKEDIN_CLIENT_ID,
+			client_secret: LINKEDIN_CLIENT_SECRET
+		})
+	});
+
+	if (!res.ok) {
+		const body = await res.text();
+		throw new Error(`LinkedIn token exchange failed (${res.status}): ${body}`);
+	}
+
+	const data = (await res.json()) as Partial<AccessTokenResponse>;
+
+	if (!data.access_token || !data.expires_in) {
+		throw new Error('LinkedIn token exchange returned an unexpected payload.');
+	}
+
+	return { access_token: data.access_token, expires_in: data.expires_in };
+}
+
+export function expiresAtFrom(expiresIn: number, now: Date = new Date()): Date {
+	return new Date(now.getTime() + expiresIn * 1000);
+}
+
+export async function saveToken(token: AccessTokenResponse): Promise<void> {
+	const { error } = await supabaseAdmin.from('linkedin_token').upsert(
+		{
+			id: TOKEN_ROW_ID,
+			access_token: token.access_token,
+			expires_at: expiresAtFrom(token.expires_in).toISOString(),
+			updated_at: new Date().toISOString()
+		},
+		{ onConflict: 'id' }
+	);
+
+	if (error) {
+		throw new Error(`Could not store the LinkedIn token: ${error.message}`);
+	}
+}
+
+async function readTokenRow(): Promise<LinkedInTokenRow | null> {
+	const { data, error } = await supabaseAdmin
+		.from('linkedin_token')
+		.select('access_token, expires_at, updated_at')
+		.eq('id', TOKEN_ROW_ID)
+		.maybeSingle();
+
+	if (error) {
+		console.error('Error reading the stored LinkedIn token:', error);
+		return null;
+	}
+
+	return data;
+}
+
+/**
+ * The access token to post with. Falls back to the `LINKEDIN_ACCESS_TOKEN` env
+ * var while no token has been stored yet, so posting keeps working between
+ * deploying this and the first reconnect.
+ */
+export function getAccessToken(status: TokenStatus): string | null {
+	return status.row?.access_token || env.LINKEDIN_ACCESS_TOKEN || null;
+}
+
+export function statusFromRow(row: LinkedInTokenRow | null, now: Date = new Date()): TokenStatus {
+	if (!row) {
+		// Nothing stored yet means the env fallback is still in play. That token
+		// has its own unknown expiry, so there is nothing to warn about until it
+		// is rejected — don't nag daily before the first reconnect.
+		return { row: null, daysUntilExpiry: null, expired: false, needsRenewal: false };
+	}
+
+	const msUntilExpiry = new Date(row.expires_at).getTime() - now.getTime();
+	const daysUntilExpiry = Math.floor(msUntilExpiry / (1000 * 60 * 60 * 24));
+	const expired = msUntilExpiry <= 0;
+
+	return {
+		row,
+		daysUntilExpiry,
+		expired,
+		needsRenewal: expired || daysUntilExpiry <= EXPIRY_WARNING_DAYS
+	};
+}
+
+export async function getTokenStatus(): Promise<TokenStatus> {
+	return statusFromRow(await readTokenRow());
+}

--- a/src/routes/api/linkedin/auth/+server.ts
+++ b/src/routes/api/linkedin/auth/+server.ts
@@ -1,0 +1,28 @@
+import { ADMIN_EMAIL } from '$env/static/private';
+import { buildAuthUrl, STATE_COOKIE } from '$lib/server/linkedin';
+import { error, redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ locals: { safeGetSession }, cookies, url }) => {
+	const { session } = await safeGetSession();
+
+	if (!session) {
+		throw error(401, 'Unauthorized');
+	}
+
+	if (session.user.email !== ADMIN_EMAIL) {
+		throw error(403, 'Forbidden');
+	}
+
+	const state = crypto.randomUUID();
+
+	cookies.set(STATE_COOKIE, state, {
+		path: '/',
+		httpOnly: true,
+		sameSite: 'lax',
+		secure: url.protocol === 'https:',
+		maxAge: 60 * 10
+	});
+
+	throw redirect(302, buildAuthUrl(state, url.origin));
+};

--- a/src/routes/api/linkedin/callback/+server.ts
+++ b/src/routes/api/linkedin/callback/+server.ts
@@ -1,0 +1,42 @@
+import { exchangeCode, saveToken, STATE_COOKIE } from '$lib/server/linkedin';
+import { redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+const RECONNECT_PAGE = '/private/linkedin';
+
+/**
+ * LinkedIn redirects the browser here after consent, so this route cannot
+ * require a session — the single-use `state` cookie set by `/api/linkedin/auth`
+ * is what ties the callback back to an admin-initiated flow.
+ */
+export const GET: RequestHandler = async ({ url, cookies }) => {
+	const expectedState = cookies.get(STATE_COOKIE);
+	cookies.delete(STATE_COOKIE, { path: '/' });
+
+	const linkedInError = url.searchParams.get('error');
+	if (linkedInError) {
+		const description = url.searchParams.get('error_description') ?? linkedInError;
+		console.error('LinkedIn denied the authorization request:', description);
+		throw redirect(303, `${RECONNECT_PAGE}?error=${encodeURIComponent(description)}`);
+	}
+
+	const state = url.searchParams.get('state');
+	if (!expectedState || state !== expectedState) {
+		console.error('LinkedIn callback state mismatch.');
+		throw redirect(303, `${RECONNECT_PAGE}?error=state_mismatch`);
+	}
+
+	const code = url.searchParams.get('code');
+	if (!code) {
+		throw redirect(303, `${RECONNECT_PAGE}?error=missing_code`);
+	}
+
+	try {
+		await saveToken(await exchangeCode(code, url.origin));
+	} catch (err) {
+		console.error('Could not complete the LinkedIn reconnect:', err);
+		throw redirect(303, `${RECONNECT_PAGE}?error=exchange_failed`);
+	}
+
+	throw redirect(303, `${RECONNECT_PAGE}?connected=1`);
+};

--- a/src/routes/api/newsletter/daily-digest/+server.ts
+++ b/src/routes/api/newsletter/daily-digest/+server.ts
@@ -1,7 +1,7 @@
 import {
+	ADMIN_EMAIL,
 	DAILY_DIGEST_SECRET_KEY,
 	FROM_EMAIL,
-	LINKEDIN_ACCESS_TOKEN,
 	LINKEDIN_ORGANIZATION_ID,
 	RESEND_API_KEY,
 	RESEND_AUDIENCE_ID
@@ -9,14 +9,46 @@ import {
 import { json, error } from '@sveltejs/kit';
 import { Resend } from 'resend';
 import { escapeHtml } from '$lib/utils';
+import { getAccessToken, getReconnectUrl, getTokenStatus } from '$lib/server/linkedin';
 import type { RequestHandler } from './$types';
 
 const resend = new Resend(RESEND_API_KEY);
+
+/**
+ * Nudges the admin to reconnect. LinkedIn only grants refresh tokens to
+ * approved Marketing Developer Platform partners, so renewal is manual and
+ * this daily mail is what keeps it from being forgotten.
+ */
+async function sendTokenWarning(reason: string) {
+	try {
+		await resend.emails.send({
+			from: FROM_EMAIL,
+			to: ADMIN_EMAIL,
+			subject: 'visPositions: LinkedIn token needs renewing',
+			text:
+				`${reason}\n\n` +
+				`Reconnect here: ${getReconnectUrl()}\n\n` +
+				`Until then the daily digest email still goes out, but nothing is posted to LinkedIn.`
+		});
+	} catch (err) {
+		console.error('Could not send the LinkedIn token warning email:', err);
+	}
+}
 
 export const POST: RequestHandler = async ({ locals: { supabase }, request }) => {
 	const authHeader = request.headers.get('Authorization');
 	if (authHeader !== `Bearer ${DAILY_DIGEST_SECRET_KEY}`) {
 		return json({ message: 'Unauthorized' }, { status: 401 });
+	}
+
+	// Checked before the no-new-posts return below, so quiet days still warn.
+	const tokenStatus = await getTokenStatus();
+	if (tokenStatus.needsRenewal) {
+		await sendTokenWarning(
+			tokenStatus.expired
+				? 'The LinkedIn access token has expired.'
+				: `The LinkedIn access token expires in ${tokenStatus.daysUntilExpiry} days.`
+		);
 	}
 
 	try {
@@ -102,13 +134,14 @@ export const POST: RequestHandler = async ({ locals: { supabase }, request }) =>
 		}
 
 		// Post to LinkedIn
-		if (LINKEDIN_ACCESS_TOKEN && LINKEDIN_ORGANIZATION_ID) {
+		const linkedinToken = getAccessToken(tokenStatus);
+		if (linkedinToken && LINKEDIN_ORGANIZATION_ID) {
 			try {
 				const linkedinRes = await fetch('https://api.linkedin.com/v2/ugcPosts', {
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',
-						Authorization: `Bearer ${LINKEDIN_ACCESS_TOKEN}`
+						Authorization: `Bearer ${linkedinToken}`
 					},
 					body: JSON.stringify({
 						author: `urn:li:organization:${LINKEDIN_ORGANIZATION_ID}`,
@@ -130,6 +163,17 @@ export const POST: RequestHandler = async ({ locals: { supabase }, request }) =>
 				if (!linkedinRes.ok) {
 					const errorText = await linkedinRes.text();
 					console.error(`Error posting to LinkedIn (${linkedinRes.status}):`, errorText);
+
+					// A rejected token can also mean early revocation, which the
+					// expiry check above would not have caught.
+					if (
+						(linkedinRes.status === 401 || linkedinRes.status === 403) &&
+						!tokenStatus.needsRenewal
+					) {
+						await sendTokenWarning(
+							`LinkedIn rejected the access token (HTTP ${linkedinRes.status}) while posting the daily digest.`
+						);
+					}
 				} else {
 					console.log('Successfully posted daily digest to LinkedIn.');
 				}

--- a/src/routes/api/newsletter/daily-digest/server.test.ts
+++ b/src/routes/api/newsletter/daily-digest/server.test.ts
@@ -1,15 +1,21 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from './+server';
+import { getTokenStatus, type TokenStatus } from '$lib/server/linkedin';
 
 // Mock $env/static/private
 vi.mock('$env/static/private', () => ({
+	ADMIN_EMAIL: 'admin@example.com',
 	DAILY_DIGEST_SECRET_KEY: 'test_secret_key',
 	FROM_EMAIL: 'test@example.com',
-	LINKEDIN_ACCESS_TOKEN: 'test_linkedin_token',
+	LINKEDIN_CLIENT_ID: 'test_client_id',
+	LINKEDIN_CLIENT_SECRET: 'test_client_secret',
 	LINKEDIN_ORGANIZATION_ID: 'test_org_id',
 	RESEND_API_KEY: 'test_api_key',
-	RESEND_AUDIENCE_ID: 'test_audience_id'
+	RESEND_AUDIENCE_ID: 'test_audience_id',
+	SUPABASE_SERVICE_ROLE_KEY: 'test_service_role_key'
 }));
+
+const sendEmail = vi.fn().mockResolvedValue({ error: null });
 
 // Mock resend
 vi.mock('resend', () => {
@@ -19,21 +25,77 @@ vi.mock('resend', () => {
 				broadcasts: {
 					create: vi.fn().mockResolvedValue({ data: { id: 'test_id' }, error: null }),
 					send: vi.fn().mockResolvedValue({ error: null })
+				},
+				emails: {
+					send: (...args: unknown[]) => sendEmail(...args)
 				}
 			};
 		})
 	};
 });
 
+vi.mock('$lib/server/linkedin', async (importOriginal) => {
+	// Keep the pure helpers, stub only the Supabase-backed read.
+	const actual = await importOriginal<typeof import('$lib/server/linkedin')>();
+	return { ...actual, getTokenStatus: vi.fn() };
+});
+
+vi.mock('$env/static/public', () => ({ PUBLIC_SUPABASE_URL: 'http://localhost:54321' }));
+
+vi.mock('$env/dynamic/private', () => ({ env: { LINKEDIN_ACCESS_TOKEN: 'env_fallback_token' } }));
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => ({ from: vi.fn() })) }));
+
+const healthyToken: TokenStatus = {
+	row: {
+		access_token: 'stored_token',
+		expires_at: new Date(Date.now() + 45 * 24 * 60 * 60 * 1000).toISOString(),
+		updated_at: new Date().toISOString()
+	},
+	daysUntilExpiry: 45,
+	expired: false,
+	needsRenewal: false
+};
+
+const expiringToken: TokenStatus = {
+	...healthyToken,
+	daysUntilExpiry: 3,
+	needsRenewal: true
+};
+
+function digestRequest(token = 'test_secret_key') {
+	return new Request('http://localhost/api/newsletter/daily-digest', {
+		method: 'POST',
+		headers: { Authorization: `Bearer ${token}` }
+	});
+}
+
+function supabaseWithPosts(posts: unknown[]) {
+	return {
+		from: vi.fn().mockReturnThis(),
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		gte: vi.fn().mockReturnThis(),
+		order: vi.fn().mockResolvedValue({ data: posts, error: null })
+	};
+}
+
+function callDigest(request: Request, supabase: unknown) {
+	return POST({ request, locals: { supabase } } as unknown as Parameters<typeof POST>[0]);
+}
+
 describe('Daily Digest API', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(getTokenStatus).mockResolvedValue(healthyToken);
+	});
+
 	it('should return 401 if Authorization header is missing', async () => {
 		const request = new Request('http://localhost/api/newsletter/daily-digest', {
 			method: 'POST'
 		});
 
-		const response = await POST({ request, locals: { supabase: {} } } as unknown as Parameters<
-			typeof POST
-		>[0]);
+		const response = await callDigest(request, {});
 		const data = await response.json();
 
 		expect(response.status).toBe(401);
@@ -41,16 +103,7 @@ describe('Daily Digest API', () => {
 	});
 
 	it('should return 401 if Authorization header is invalid', async () => {
-		const request = new Request('http://localhost/api/newsletter/daily-digest', {
-			method: 'POST',
-			headers: {
-				Authorization: 'Bearer wrong_key'
-			}
-		});
-
-		const response = await POST({ request, locals: { supabase: {} } } as unknown as Parameters<
-			typeof POST
-		>[0]);
+		const response = await callDigest(digestRequest('wrong_key'), {});
 		const data = await response.json();
 
 		expect(response.status).toBe(401);
@@ -60,24 +113,7 @@ describe('Daily Digest API', () => {
 	it('should return 200 with no new posts message if there are no new posts', async () => {
 		const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-		const request = new Request('http://localhost/api/newsletter/daily-digest', {
-			method: 'POST',
-			headers: {
-				Authorization: 'Bearer test_secret_key'
-			}
-		});
-
-		const supabase = {
-			from: vi.fn().mockReturnThis(),
-			select: vi.fn().mockReturnThis(),
-			eq: vi.fn().mockReturnThis(),
-			gte: vi.fn().mockReturnThis(),
-			order: vi.fn().mockResolvedValue({ data: [], error: null })
-		};
-
-		const response = await POST({ request, locals: { supabase } } as unknown as Parameters<
-			typeof POST
-		>[0]);
+		const response = await callDigest(digestRequest(), supabaseWithPosts([]));
 		const data = await response.json();
 
 		expect(response.status).toBe(200);
@@ -85,5 +121,61 @@ describe('Daily Digest API', () => {
 		expect(consoleSpy).toHaveBeenCalledWith('No newly vetted posts found in the last 24 hours.');
 
 		consoleSpy.mockRestore();
+	});
+
+	it('does not email about the token while it is healthy', async () => {
+		await callDigest(digestRequest(), supabaseWithPosts([]));
+
+		expect(sendEmail).not.toHaveBeenCalled();
+	});
+
+	it('warns the admin when the token is close to expiring', async () => {
+		vi.mocked(getTokenStatus).mockResolvedValue(expiringToken);
+
+		await callDigest(digestRequest(), supabaseWithPosts([]));
+
+		expect(sendEmail).toHaveBeenCalledTimes(1);
+		const mail = sendEmail.mock.calls[0][0];
+		expect(mail.to).toBe('admin@example.com');
+		expect(mail.text).toContain('expires in 3 days');
+		expect(mail.text).toContain('/private/linkedin');
+	});
+
+	it('warns even on a day with no new posts', async () => {
+		vi.mocked(getTokenStatus).mockResolvedValue({ ...expiringToken, expired: true });
+		const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+		const response = await callDigest(digestRequest(), supabaseWithPosts([]));
+
+		expect(await response.json()).toEqual({ message: 'No new posts to send.' });
+		expect(sendEmail).toHaveBeenCalledTimes(1);
+		expect(sendEmail.mock.calls[0][0].text).toContain('has expired');
+
+		consoleSpy.mockRestore();
+	});
+
+	it('warns immediately when LinkedIn rejects the token', async () => {
+		const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('revoked', { status: 401 })));
+
+		await callDigest(
+			digestRequest(),
+			supabaseWithPosts([
+				{
+					id: 1,
+					title: 'A job',
+					description: 'A description',
+					created_at: new Date().toISOString()
+				}
+			])
+		);
+
+		expect(sendEmail).toHaveBeenCalledTimes(1);
+		expect(sendEmail.mock.calls[0][0].text).toContain('HTTP 401');
+
+		vi.unstubAllGlobals();
+		consoleLog.mockRestore();
+		consoleError.mockRestore();
 	});
 });

--- a/src/routes/private/linkedin/+page.server.ts
+++ b/src/routes/private/linkedin/+page.server.ts
@@ -1,0 +1,28 @@
+import { ADMIN_EMAIL } from '$env/static/private';
+import { getTokenStatus } from '$lib/server/linkedin';
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ locals: { safeGetSession } }) => {
+	const { session } = await safeGetSession();
+
+	if (!session) {
+		throw error(401, 'Unauthorized');
+	}
+
+	if (session.user.email !== ADMIN_EMAIL) {
+		throw error(403, 'Forbidden');
+	}
+
+	const { row, daysUntilExpiry, expired, needsRenewal } = await getTokenStatus();
+
+	// Never send the token itself to the browser.
+	return {
+		connected: row !== null,
+		expiresAt: row?.expires_at ?? null,
+		updatedAt: row?.updated_at ?? null,
+		daysUntilExpiry,
+		expired,
+		needsRenewal
+	};
+};

--- a/src/routes/private/linkedin/+page.svelte
+++ b/src/routes/private/linkedin/+page.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	const errorMessages: Record<string, string> = {
+		state_mismatch: 'The authorization request could not be verified. Please try again.',
+		missing_code: 'LinkedIn did not return an authorization code. Please try again.',
+		exchange_failed: 'Exchanging the authorization code failed. Check the server logs.'
+	};
+
+	let connected = $derived(page.url.searchParams.get('connected') === '1');
+	let errorParam = $derived(page.url.searchParams.get('error'));
+	let errorMessage = $derived(errorParam ? (errorMessages[errorParam] ?? errorParam) : null);
+
+	function formatDate(value: string | null): string {
+		return value ? new Date(value).toLocaleString() : '—';
+	}
+
+	let statusLine = $derived.by(() => {
+		if (!data.connected)
+			return 'No token stored yet — still using the LINKEDIN_ACCESS_TOKEN env var.';
+		if (data.expired)
+			return 'The stored token has expired. The digest cannot post until you reconnect.';
+		if (data.needsRenewal) return `Expires in ${data.daysUntilExpiry} days — time to reconnect.`;
+		return `Valid for another ${data.daysUntilExpiry} days.`;
+	});
+</script>
+
+<div class="flex flex-col gap-6">
+	<div class="flex flex-col gap-2">
+		<h1 class="border-b">LinkedIn Connection</h1>
+		<p>
+			The daily digest posts to the visPositions LinkedIn page with an access token that LinkedIn
+			expires after 60 days. Reconnecting here stores a fresh one — no redeploy needed.
+		</p>
+	</div>
+
+	{#if connected}
+		<p class="rounded border border-green-600 bg-green-50 px-3 py-2 text-green-800">
+			LinkedIn reconnected successfully.
+		</p>
+	{/if}
+
+	{#if errorMessage}
+		<p class="rounded border border-red-500 bg-red-50 px-3 py-2 text-red-700">{errorMessage}</p>
+	{/if}
+
+	<dl class="flex flex-col gap-2">
+		<div class="flex gap-2">
+			<dt class="w-40 font-semibold">Status</dt>
+			<dd>{statusLine}</dd>
+		</div>
+		<div class="flex gap-2">
+			<dt class="w-40 font-semibold">Expires at</dt>
+			<dd>{formatDate(data.expiresAt)}</dd>
+		</div>
+		<div class="flex gap-2">
+			<dt class="w-40 font-semibold">Last reconnected</dt>
+			<dd>{formatDate(data.updatedAt)}</dd>
+		</div>
+	</dl>
+
+	<a
+		href="/api/linkedin/auth"
+		data-sveltekit-reload
+		class="bg-primary hover:bg-primary-light flex w-fit items-center gap-2 rounded border px-2 py-1.5 text-white transition-all hover:shadow-md"
+	>
+		Reconnect LinkedIn
+	</a>
+</div>


### PR DESCRIPTION
## Why

The daily digest posts to the LinkedIn org page with an access token LinkedIn expires after 60 days. Renewing meant driving the OAuth exchange by hand (via Requestly), pasting the result into Vercel, and redeploying.

Auto-refresh isn't available: [LinkedIn grants programmatic refresh tokens only to approved Marketing Developer Platform partners](https://learn.microsoft.com/en-us/linkedin/shared/authentication/programmatic-refresh-tokens). So renewal stays manual — this makes it two clicks, and makes sure it isn't forgotten.

## What changed

- **`src/lib/server/linkedin.ts`** — OAuth helpers plus reads/writes of the token through the service-role Supabase client, following the pattern in `webhooks/google-sheets/+server.ts`.
- **`/api/linkedin/auth`** — admin-gated, sets a single-use `state` cookie, redirects to LinkedIn.
- **`/api/linkedin/callback`** — verifies `state`, exchanges the code, stores the token. Can't require a session since LinkedIn is the caller; the `state` cookie is what ties it to an admin-initiated flow.
- **`/private/linkedin`** — shows expiry, days remaining and last reconnect, with a Reconnect button. The token itself never reaches the browser.
- **`daily-digest/+server.ts`** — reads the stored token; checks expiry *before* the no-new-posts early return so quiet days still warn; emails `ADMIN_EMAIL` within 7 days of expiry or immediately on a 401/403.

Two notes on the implementation:

- The `LINKEDIN_ACCESS_TOKEN` fallback is read via `$env/dynamic/private`, not static — a static import is inlined at build time, so deleting the var from Vercel (the intended cleanup) would otherwise break the build.
- No warning email fires while the DB row is empty. Before the first reconnect there's no expiry to reason about, so a daily mail would just be noise.

## Deploy steps

1. In the Supabase SQL editor (RLS on, **no policies** — service-role only):
   ```sql
   create table public.linkedin_token (
     id smallint primary key default 1 check (id = 1),
     access_token text not null,
     expires_at timestamptz not null,
     updated_at timestamptz not null default now()
   );
   alter table public.linkedin_token enable row level security;
   ```
2. LinkedIn app → Auth → add `https://vispositions.com/api/linkedin/callback` as an authorized redirect URL.
3. Vercel → add `LINKEDIN_CLIENT_ID` and `LINKEDIN_CLIENT_SECRET`. Keep `LINKEDIN_ACCESS_TOKEN` until after the first reconnect, then delete it.
4. Deploy, open `/private/linkedin`, click Reconnect.

⚠️ The scope constant is `w_organization_social` (`src/lib/server/linkedin.ts`). If the app requests something different today, that needs to match — LinkedIn rejects authorization for a scope the app isn't approved for.

## Testing

72 tests pass, `bun run check` clean, prettier and eslint clean. New coverage: expiry math and the 7-day boundary, env bootstrap fallback, code-exchange success and both failure modes, and digest cases for the warning firing in-window, staying quiet when healthy, firing on a no-posts day, and firing on a 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)