### PR TITLE
🌐 Point SITE_URL at the canonical www domain

### DIFF
--- a/src/lib/server/linkedin.ts
+++ b/src/lib/server/linkedin.ts
@@ -13,7 +13,8 @@ import { createClient } from '@supabase/supabase-js';
 // can read or write it.
 const supabaseAdmin = createClient(PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
-export const SITE_URL = 'https://vispositions.com';
+/** Canonical domain — the apex 308-redirects here. */
+export const SITE_URL = 'https://www.vispositions.com';
 
 /** Scope the LinkedIn app is approved for. Posting to the org page needs this one. */
 export const LINKEDIN_SCOPE = 'w_organization_social';


### PR DESCRIPTION
Follow-up to #97, which merged before this landed.

`SITE_URL` was set to the apex `https://vispositions.com`, but the apex 308-redirects to `https://www.vispositions.com` — so the reconnect link in the token-expiry warning email was taking a needless hop.

This only affects the link in that email. The OAuth `redirect_uri` is built from the origin the admin is actually browsing, not from this constant, so token renewal itself is unaffected.

Verified with:

```
curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}\n" https://vispositions.com/
308 -> https://www.vispositions.com/
```

72 tests pass, lint and type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)